### PR TITLE
fix: 使用react-native-material-textfield组件使用vaule属性异常

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -292,7 +292,7 @@ export default class TextField extends PureComponent {
 
     let value = this.isDefaultVisible()?
       defaultValue:
-      text;
+      this.props.value;
 
     if (null == value) {
       return '';


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
  Closes #4 
- 这个功能是什么？（如果适用）
  react-native-material-textfield组件vaule属性无法重新设置文本
- 您是如何实现解决方案的？
  问题定位：react-native-material-textfield\src\components\field文件下面的index.js
  value() {
      let { text } = this.state;
      let { defaultValue } = this.props;
      let value = this.isDefaultVisible()?
      defaultValue:
     text; ---------日志定位，这个text值没有变化
     ...
 }
 重新设置value属性时日志定位text值没有变化
 解决方案：
 value() {
      let { text } = this.state;
      let { defaultValue } = this.props;
      let value = this.isDefaultVisible()?
      defaultValue:
     this.props.value;
     ...
 }
修改后value属性可以获取值

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
测试用例地址：https://github.com/MyAndroidNetZWJ/RNOHDCS/tree/main/react-native-material-dropdown

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X]  已经在真机设备或模拟器上测试通过
- [X]  已经与 Android 或 iOS 平台做过效果/功能对比
- [X]  已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [X]  更新了 JS/TS 代码 (如有)

