### PR TITLE
fix(react-native-material-textfield)：设置文本后无法删除

### DIFF
--- a/src/components/field/index.js
+++ b/src/components/field/index.js
@@ -292,7 +292,7 @@ export default class TextField extends PureComponent {
 
     let value = this.isDefaultVisible()?
       defaultValue:
-      this.props.value;
+      text;
 
     if (null == value) {
       return '';


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
close #7 
请解释此次更改的 **动机**，以下是一些帮助您的要点：
手动设置文本后无法删除

## Test Plan

测试代码地址：https://github.com/react-native-oh-library/RNOHDCS/blob/main/react-native-material-textfield/TextFieldDemo.tsx

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [x] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)


